### PR TITLE
Fix 13

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,10 +70,6 @@ afterOpenClass | string | ```toggle-widget--after-open``` | after-open state cla
 offsetTopShift | number | -20 | shift the offset top value by this before returning. Set to 0 to disable.
 scrollDuration | number | 300 | scrollToOffsetTop() animation duration
 
-## License
-
-[MIT License](https://github.com/floriancapelle/jquery-toggle-widget/blob/master/LICENSE)
-
 ------------------
 
 ## Questions & Contribution

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ enabled | boolean | true | whether the plugin will be enabled (on startup), use 
 toggleBtnSelector | string/boolean | ```toggle-widget__toggle-btn``` | will be used as DOM filter in the event handler. Set to false to disable event handling (and do it manually).
 toggleContentSelector | string/function | ```.toggle-widget__content``` | root element find() filter string or function to return the target toggle content element. Function context is api, first argument root element. 'toggleContent' may be used, but is deprecated and will be removed.
 openClass | string | ```toggle-widget--open``` | open state class
+afterOpenClass | string | ```toggle-widget--after-open``` | after-open state class
 offsetTopShift | number | -20 | shift the offset top value by this before returning. Set to 0 to disable.
 scrollDuration | number | 300 | scrollToOffsetTop() animation duration
 

--- a/jquery.toggle-widget.js
+++ b/jquery.toggle-widget.js
@@ -1,4 +1,4 @@
-/*! jQuery toggleWidget - v1.0.5
+/*! jQuery toggleWidget - v1.0.6
  * https://github.com/floriancapelle/jquery-toggle-widget
  * Licensed MIT
  */
@@ -28,6 +28,7 @@
         toggleBtnSelector: '.toggle-widget__toggle-btn',
         toggleContentSelector: '.toggle-widget__content',
         openClass: 'toggle-widget--open',
+        afterOpenClass: 'toggle-widget--after-open',
         offsetTopShift: -20,
         scrollDuration: 300
     };
@@ -118,6 +119,7 @@
                     // remove attached events again after firing at least one
                     $toggleContent.off('.open.' + NAMESPACE);
 
+                    $el.addClass(options.afterOpenClass);
                     $el.trigger('afterOpen.' + NAMESPACE, self);
                 });
 
@@ -134,6 +136,7 @@
                 if ( isOpen === false ) return this;
                 if ( isEnabled === false ) return this;
 
+                $el.removeClass(options.afterOpenClass);
                 $el.trigger('beforeClose.' + NAMESPACE, this);
 
                 var contentInnerHeight = this.getContentInnerHeight();


### PR DESCRIPTION
- add afterOpenClass option
- afterOpenClass will be added after the widget has fully opened
- afterOpenClass will be removed before the widget has started to open